### PR TITLE
fix android arm64

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -26,7 +26,7 @@ case "${ARCH}" in
     download_v2ray_link="${official_v2ray_link}/download/${latest_v2ray_version}/v2ray-linux-arm32-v7a.zip"
     ;;
   arm64)
-    download_v2ray_link="${official_v2ray_link}/download/${latest_v2ray_version}/v2ray-linux-arm64-v8a.zip"
+    download_v2ray_link="${official_v2ray_link}/download/${latest_v2ray_version}/v2ray-android-arm64-v8a.zip"
     ;;
   x86)
     download_v2ray_link="${official_v2ray_link}/download/${latest_v2ray_version}/v2ray-linux-32.zip"


### PR DESCRIPTION
Fixes #80
[v2ray-core v4.34.0](https://github.com/v2fly/v2ray-core/releases/tag/v4.34.0) 增加了Android ARM64 的 release，修复了v2ray无法启动的问题。
已将Android ARM64对应的下载地址由 linux-arm64-v8a 改为 android-arm64-v8a